### PR TITLE
NETCONF RFC6241 and RFC6242 conformance fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,12 @@ target
 .settings
 .project
 .classpath
+
+# IntelliJ #
+*.iml
+.idea/
+.gradle/
+gradle/
+libraries/
+gradlew
+gradlew.bat

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.juniper.netconf</groupId>
     <artifactId>netconf-java</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/net/juniper/netconf/Device.java
+++ b/src/main/java/net/juniper/netconf/Device.java
@@ -7,7 +7,11 @@
 
 package net.juniper.netconf;
 
-import com.jcraft.jsch.*;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.ChannelSubsystem;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -773,11 +777,11 @@ public class Device {
      *
      * @param configFile Path name of file containing configuration,in text/xml format,
      *                   to be loaded. For example,
-     *                   " system {
-     *                   services {
-     *                   ftp;
-     *                   }
-     *                   }"
+     *                   "system {
+     *                      services {
+     *                          ftp;
+     *                      }
+     *                    }"
      *                   will load 'ftp' under the 'systems services' hierarchy.
      *                   OR
      *                   "&lt;configuration&gt;&lt;system&gt;&lt;services&gt;&lt;ftp/&gt;&lt;

--- a/src/main/java/net/juniper/netconf/Device.java
+++ b/src/main/java/net/juniper/netconf/Device.java
@@ -7,11 +7,7 @@
 
 package net.juniper.netconf;
 
-import com.jcraft.jsch.ChannelExec;
-import com.jcraft.jsch.ChannelSubsystem;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Session;
+import com.jcraft.jsch.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -34,7 +30,7 @@ import java.util.List;
  * A <code>Device</code> is used to define a Netconf server.
  * <p>
  * A new device is created using the Device.Builder.build()
- *
+ * <p>
  * Example:
  * <pre>
  * {@code}
@@ -121,7 +117,7 @@ public class Device {
             throw new NetconfException("Strict Host Key checking requires setting the hostKeysFileName");
         }
 
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance() ;
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         try {
             builder = factory.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
@@ -143,23 +139,24 @@ public class Device {
      */
     private List<String> getDefaultClientCapabilities() {
         List<String> defaultCap = new ArrayList<>();
-        defaultCap.add("urn:ietf:params:xml:ns:netconf:base:1.0");
-        defaultCap.add("urn:ietf:params:xml:ns:netconf:base:1.0#candidate");
-        defaultCap.add("urn:ietf:params:xml:ns:netconf:base:1.0#confirmed-commit");
-        defaultCap.add("urn:ietf:params:xml:ns:netconf:base:1.0#validate");
-        defaultCap.add("urn:ietf:params:xml:ns:netconf:base:1.0#url?protocol=http,ftp,file");
+        defaultCap.add(NetconfConstants.URN_IETF_PARAMS_NETCONF_BASE_1_0);
+        defaultCap.add(NetconfConstants.URN_IETF_PARAMS_NETCONF_BASE_1_0 + "#candidate");
+        defaultCap.add(NetconfConstants.URN_IETF_PARAMS_NETCONF_BASE_1_0 + "#confirmed-commit");
+        defaultCap.add(NetconfConstants.URN_IETF_PARAMS_NETCONF_BASE_1_0 + "#validate");
+        defaultCap.add(NetconfConstants.URN_IETF_PARAMS_NETCONF_BASE_1_0 + "#url?protocol=http,ftp,file");
         return defaultCap;
     }
 
     /**
      * Given a list of netconf capabilities, generate the netconf hello rpc message.
+     * https://tools.ietf.org/html/rfc6241#section-8.1
      *
      * @param capabilities A list of netconf capabilities
      * @return the hello RPC that represents those capabilities.
      */
     private String createHelloRPC(List<String> capabilities) {
         StringBuilder helloRPC = new StringBuilder();
-        helloRPC.append("<hello>\n");
+        helloRPC.append("<hello xmlns=\"" + NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0 + "\">\n");
         helloRPC.append("<capabilities>\n");
         for (Object o : capabilities) {
             String capability = (String) o;
@@ -170,17 +167,17 @@ public class Device {
         }
         helloRPC.append("</capabilities>\n");
         helloRPC.append("</hello>\n");
-        helloRPC.append("]]>]]>\n");
+        helloRPC.append(NetconfConstants.DEVICE_PROMPT);
         return helloRPC.toString();
     }
 
     /**
-         * Create a new Netconf session.
-         *
-         * @return NetconfSession
-         * @throws NetconfException if there are issues communicating with the Netconf server.
-         */
-        private NetconfSession createNetconfSession() throws NetconfException {
+     * Create a new Netconf session.
+     *
+     * @return NetconfSession
+     * @throws NetconfException if there are issues communicating with the Netconf server.
+     */
+    private NetconfSession createNetconfSession() throws NetconfException {
         if (!isConnected()) {
             sshClient = new JSch();
 
@@ -308,7 +305,6 @@ public class Device {
      * Close the connection to the Netconf server. All associated Netconf
      * sessions will be closed, too. Can be called at any time. Don't forget to
      * call this once you don't need the device anymore.
-     *
      */
     public void close() {
         if (!isConnected()) {
@@ -331,7 +327,7 @@ public class Device {
         }
         ChannelExec channel;
         try {
-            channel = (ChannelExec)sshSession.openChannel("exec");
+            channel = (ChannelExec) sshSession.openChannel("exec");
         } catch (JSchException e) {
             throw new NetconfException(String.format("Failed to open exec session: %s", e.getMessage()));
         }
@@ -376,7 +372,7 @@ public class Device {
         }
         ChannelExec channel;
         try {
-            channel = (ChannelExec)sshSession.openChannel("exec");
+            channel = (ChannelExec) sshSession.openChannel("exec");
         } catch (JSchException e) {
             throw new NetconfException(String.format("Failed to open exec session: %s", e.getMessage()));
         }
@@ -396,7 +392,7 @@ public class Device {
      *                   "get-chassis-inventory" OR
      *                   "&lt;rpc&gt;&lt;get-chassis-inventory/&gt;&lt;/rpc&gt;"
      * @return RPC reply sent by Netconf server
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public XML executeRPC(String rpcContent) throws SAXException, IOException {
@@ -415,7 +411,7 @@ public class Device {
      * @param rpc RPC to be sent. Use the XMLBuilder to create RPC as an
      *            XML object.
      * @return RPC reply sent by Netconf server
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public XML executeRPC(XML rpc) throws SAXException, IOException {
@@ -433,7 +429,7 @@ public class Device {
      *
      * @param rpcDoc RPC content to be sent, as a org.w3c.dom.Document object.
      * @return RPC reply sent by Netconf server
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public XML executeRPC(Document rpcDoc) throws SAXException, IOException {
@@ -525,8 +521,8 @@ public class Device {
      * Check if the last RPC reply returned from Netconf server has any error.
      *
      * @return true if any errors are found in last RPC reply.
-     * @throws SAXException if there are issues parsing XML from the device.
-     * @throws IOException if there are issues communicating with the device.
+     * @throws SAXException          if there are issues parsing XML from the device.
+     * @throws IOException           if there are issues communicating with the device.
      * @throws IllegalStateException if the connection is not established
      */
     public boolean hasError() throws SAXException, IOException {
@@ -542,7 +538,7 @@ public class Device {
      *
      * @return true if any errors are found in last RPC reply.
      * @throws SAXException if there are issues parsing XML from the device.
-     * @throws IOException if there are issues communicating with the device.
+     * @throws IOException  if there are issues communicating with the device.
      */
     public boolean hasWarning() throws SAXException, IOException {
         if (netconfSession == null) {
@@ -571,9 +567,9 @@ public class Device {
      * Locks the candidate configuration.
      *
      * @return true if successful.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
-     * @throws IllegalStateException if the connection is not established
+     * @throws IllegalStateException    if the connection is not established
      */
     public boolean lockConfig() throws IOException, SAXException {
         if (netconfSession == null) {
@@ -587,7 +583,7 @@ public class Device {
      * Unlocks the candidate configuration.
      *
      * @return true if successful.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public boolean unlockConfig() throws IOException, SAXException {
@@ -606,7 +602,7 @@ public class Device {
      *                      &lt;services/&gt;&lt;/system&gt;&lt;/configuration/&gt;"
      *                      will load 'ftp' under the 'systems services' hierarchy.
      * @param loadType      You can choose "merge" or "replace" as the loadType.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public void loadXMLConfiguration(String configuration, String loadType)
@@ -630,7 +626,7 @@ public class Device {
      *                      }"
      *                      will load 'ftp' under the 'systems services' hierarchy.
      * @param loadType      You can choose "merge" or "replace" as the loadType.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public void loadTextConfiguration(String configuration, String loadType)
@@ -651,7 +647,7 @@ public class Device {
      *                      "set system services ftp"
      *                      will load 'ftp' under the 'systems services' hierarchy.
      *                      To load multiple set statements, separate them by '\n' character.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public void loadSetConfiguration(String configuration) throws
@@ -671,7 +667,7 @@ public class Device {
      * @param configFile Path name of file containing configuration,in xml format,
      *                   to be loaded.
      * @param loadType   You can choose "merge" or "replace" as the loadType.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public void loadXMLFile(String configFile, String loadType)
@@ -690,7 +686,7 @@ public class Device {
      * @param configFile Path name of file containing configuration,in xml format,
      *                   to be loaded.
      * @param loadType   You can choose "merge" or "replace" as the loadType.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public void loadTextFile(String configFile, String loadType)
@@ -709,7 +705,7 @@ public class Device {
      *
      * @param configFile Path name of file containing configuration,in set format,
      *                   to be loaded.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public void loadSetFile(String configFile) throws
@@ -725,8 +721,8 @@ public class Device {
      * Commit the candidate configuration.
      *
      * @throws net.juniper.netconf.CommitException if there was an error committing the configuration.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
-     * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
+     * @throws java.io.IOException                 If there are errors communicating with the netconf server.
+     * @throws org.xml.sax.SAXException            If there are errors parsing the XML reply.
      */
     public void commit() throws CommitException, IOException, SAXException {
         if (netconfSession == null) {
@@ -743,8 +739,8 @@ public class Device {
      * @param seconds Time in seconds, after which the previous active configuration
      *                is reverted back to.
      * @throws net.juniper.netconf.CommitException if there was an error committing the configuration.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
-     * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
+     * @throws java.io.IOException                 If there are errors communicating with the netconf server.
+     * @throws org.xml.sax.SAXException            If there are errors parsing the XML reply.
      */
     public void commitConfirm(long seconds) throws CommitException, IOException,
             SAXException {
@@ -760,8 +756,8 @@ public class Device {
      * check the configuration for changes. A normal commit only signals processes where there data has been modified.
      *
      * @throws CommitException if there is an error committing the config.
-     * @throws IOException if there is an error communicating with the Netconf server.
-     * @throws SAXException if there is an error parsing the XML Netconf response.
+     * @throws IOException     if there is an error communicating with the Netconf server.
+     * @throws SAXException    if there is an error parsing the XML Netconf response.
      */
     public void commitFull() throws CommitException, IOException, SAXException {
         if (netconfSession == null) {
@@ -776,21 +772,21 @@ public class Device {
      * text/xml format.
      *
      * @param configFile Path name of file containing configuration,in text/xml format,
-     *  to be loaded. For example,
-     *  " system {
-     *      services {
-     *        ftp;
-     *      }
-     *    }"
-     *  will load 'ftp' under the 'systems services' hierarchy.
-     *  OR
-     *  "&lt;configuration&gt;&lt;system&gt;&lt;services&gt;&lt;ftp/&gt;&lt;
-     *  services/&gt;&lt;/system&gt;&lt;/configuration/&gt;"
-     *  will load 'ftp' under the 'systems services' hierarchy.
+     *                   to be loaded. For example,
+     *                   " system {
+     *                   services {
+     *                   ftp;
+     *                   }
+     *                   }"
+     *                   will load 'ftp' under the 'systems services' hierarchy.
+     *                   OR
+     *                   "&lt;configuration&gt;&lt;system&gt;&lt;services&gt;&lt;ftp/&gt;&lt;
+     *                   services/&gt;&lt;/system&gt;&lt;/configuration/&gt;"
+     *                   will load 'ftp' under the 'systems services' hierarchy.
      * @param loadType   You can choose "merge" or "replace" as the loadType.
      * @throws net.juniper.netconf.CommitException if there was an error committing the configuration.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
-     * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
+     * @throws java.io.IOException                 If there are errors communicating with the netconf server.
+     * @throws org.xml.sax.SAXException            If there are errors parsing the XML reply.
      */
     public void commitThisConfiguration(String configFile, String loadType)
             throws CommitException, IOException, SAXException {
@@ -808,7 +804,7 @@ public class Device {
      *                   For example, to get the whole configuration, argument should be
      *                   &lt;configuration&gt;&lt;/configuration&gt;
      * @return configuration data as XML object.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public XML getCandidateConfig(String configTree) throws SAXException,
@@ -827,7 +823,7 @@ public class Device {
      *                   For example, to get the whole configuration, argument should be
      *                   &lt;configuration&gt;&lt;/configuration&gt;
      * @return configuration data as XML object.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public XML getRunningConfig(String configTree) throws SAXException,
@@ -843,7 +839,7 @@ public class Device {
      * Retrieve the whole candidate configuration.
      *
      * @return configuration data as XML object.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public XML getCandidateConfig() throws SAXException, IOException {
@@ -858,7 +854,7 @@ public class Device {
      * Retrieve the whole running configuration.
      *
      * @return configuration data as XML object.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public XML getRunningConfig() throws SAXException, IOException {
@@ -873,7 +869,7 @@ public class Device {
      * Validate the candidate configuration.
      *
      * @return true if validation successful.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public boolean validate() throws IOException, SAXException {
@@ -890,7 +886,7 @@ public class Device {
      *
      * @param command the cli command to be executed.
      * @return result of the command.
-     * @throws java.io.IOException If there are errors communicating with the netconf server.
+     * @throws java.io.IOException      If there are errors communicating with the netconf server.
      * @throws org.xml.sax.SAXException If there are errors parsing the XML reply.
      */
     public String runCliCommand(String command) throws IOException, SAXException {

--- a/src/main/java/net/juniper/netconf/NetconfConstants.java
+++ b/src/main/java/net/juniper/netconf/NetconfConstants.java
@@ -1,0 +1,31 @@
+package net.juniper.netconf;
+
+/**
+ * @author Jonas Glass
+ */
+public class NetconfConstants {
+
+    /**
+     * Device prompt for the framing protocol.
+     * https://tools.ietf.org/html/rfc6242#section-4.1
+     */
+    public static final String DEVICE_PROMPT = "]]>]]>";
+
+    /**
+     * XML Schema prefix.
+     */
+    public static final String XML_VERSION = "<?xml version=\"1.0\" encoding=\"utf-8\"?>";
+
+    /**
+     * XML Namespace for NETCONF Base 1.0
+     * https://tools.ietf.org/html/rfc6241#section-8.1
+     */
+    public static final String URN_XML_NS_NETCONF_BASE_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0";
+
+    /**
+     * URN for NETCONF Base 1.0
+     * https://tools.ietf.org/html/rfc6241#section-8.1
+     */
+    public static final String URN_IETF_PARAMS_NETCONF_BASE_1_0 = "urn:ietf:params:netconf:base:1.0";
+
+}

--- a/src/main/java/net/juniper/netconf/NetconfSession.java
+++ b/src/main/java/net/juniper/netconf/NetconfSession.java
@@ -20,7 +20,13 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -173,11 +179,11 @@ public class NetconfSession {
      * format.
      *
      * @param configuration Configuration,in text/tree format, to be loaded. For example,
-     *                      " system {
-     *                      services {
-     *                      ftp;
-     *                      }
-     *                      }"
+     *                      "system {
+     *                          services {
+     *                              ftp;
+     *                          }
+     *                       }"
      *                      will load 'ftp' under the 'systems services' hierarchy.
      * @param loadType      You can choose "merge" or "replace" as the loadType.
      * @throws org.xml.sax.SAXException If there are issues parsing the config file.
@@ -257,9 +263,9 @@ public class NetconfSession {
      * @param rpcContent RPC content to be sent. For example, to send an rpc
      *                   &lt;rpc&gt;&lt;get-chassis-inventory/&gt;&lt;/rpc&gt;, the
      *                   String to be passed can be
-     *                   "&lt;get-chassis-inventory/&gt;" OR
-     *                   "get-chassis-inventory" OR
-     *                   "&lt;rpc&gt;&lt;get-chassis-inventory/&gt;&lt;/rpc&gt;"
+     *                      "&lt;get-chassis-inventory/&gt;" OR
+     *                      "get-chassis-inventory" OR
+     *                      "&lt;rpc&gt;&lt;get-chassis-inventory/&gt;&lt;/rpc&gt;"
      * @return RPC reply sent by Netconf server
      * @throws org.xml.sax.SAXException If the XML Reply cannot be parsed.
      * @throws java.io.IOException      If there are issues communicating with the netconf server.
@@ -334,9 +340,9 @@ public class NetconfSession {
      * @param rpcContent RPC content to be sent. For example, to send an rpc
      *                   &lt;rpc&gt;&lt;get-chassis-inventory/&gt;&lt;/rpc&gt;, the
      *                   String to be passed can be
-     *                   "&lt;get-chassis-inventory/&gt;" OR
-     *                   "get-chassis-inventory" OR
-     *                   "&lt;rpc&gt;&lt;get-chassis-inventory/&gt;&lt;/rpc&gt;"
+     *                      "&lt;get-chassis-inventory/&gt;" OR
+     *                      "get-chassis-inventory" OR
+     *                      "&lt;rpc&gt;&lt;get-chassis-inventory/&gt;&lt;/rpc&gt;"
      * @return RPC reply sent by Netconf server as a BufferedReader. This is
      * useful if we want continuous stream of output, rather than wait
      * for whole output till command execution completes.
@@ -600,10 +606,10 @@ public class NetconfSession {
      *
      * @param configFile Path name of file containing configuration,in text/xml/set format,
      *                   to be loaded. For example,
-     *                   " system {
-     *                   services {
-     *                   ftp;
-     *                   }
+     *                   "system {
+     *                      services {
+     *                          ftp;
+     *                      }
      *                   }"
      *                   will load 'ftp' under the 'systems services' hierarchy.
      *                   OR


### PR DESCRIPTION
**NETCONF RFC6241 and RFC6242 conformance fixes**


__XML Version Conformance (RFC6241 Section 3)__
> All NETCONF messages MUST be well-formed XML ...
> A NETCONF message MAY begin with an XML declaration ...

Added XML declaration before every NETCONF message

__Hello Message Conformance (RFC6241 Section 8.1)__
> Each peer MUST send at least the base NETCONF capability, "urn:ietf:params:netconf:base:1.1"

Fixed wrong URN in hello message xmlns and capability (using 1.0 of course)

**RPC message conformance (RFC6241 Section 4.1)**
> The <rpc> element has a mandatory attribute "message-id", which is a
string chosen by the sender
 
Added the message-id element to RPCs. Also added XML NS to RPC as an attribute since it is present in all standards and most implementations.

**Framing Protocol Conformance (RFC6242 Section 4.1)**
The device prompt (`]]>]]>`) signals the end of a NETCONF message. In the current implementation the device prompt was only detected if it was followed by a \n since `readLine()` was used. This is not in conformance to the RFC. I changed it to reading character by character so that the end of a NETCONF message is also detected if the prompt is not being followed by a line break. 

**Using UTF8 encoding (RFC6241 Section 3)**
>All NETCONF messages MUST be well-formed XML, encoded in UTF-8

Changed encoding and decoding to force-use UTF-8 instead of system default.

**Extracting reused strings**
Extracted constants which have been used in multiple places and classes to a seperate class.

**Added debugging**
Added debug-logging upon receiving of a NETCONF messages. Currently it was only logged when sending a NETCONF message.

**Updated gitignore**
Added IntelliJ folders to git ignore.