### PR TITLE
Allow for a timeout value of 0 (i.e., no timeouts)

### DIFF
--- a/src/main/java/net/juniper/netconf/NetconfSession.java
+++ b/src/main/java/net/juniper/netconf/NetconfSession.java
@@ -123,8 +123,8 @@ public class NetconfSession {
         boolean timeoutNotExceeded = true;
         StringBuilder rpcReply = new StringBuilder();
         final long startTime = System.nanoTime();
-        while ((rpcReply.indexOf(NetconfConstants.DEVICE_PROMPT) < 0) &&
-                (timeoutNotExceeded = (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) < commandTimeout))) {
+        while ((rpcReply.indexOf(NetconfConstants.DEVICE_PROMPT) < 0) && (commandTimeout == 0 ||
+                (timeoutNotExceeded = (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) < commandTimeout)))) {
             if (bufferedReader.ready()) {
                 int charsRead = bufferedReader.read(buffer);
                 if (charsRead == -1) {
@@ -139,7 +139,7 @@ public class NetconfSession {
                 }
             }
         }
-        if (!timeoutNotExceeded)
+        if (commandTimeout != 0 && !timeoutNotExceeded)
             throw new SocketTimeoutException("Command timeout limit was exceeded: " + commandTimeout);
         // fixing the rpc reply by removing device prompt
         log.debug("Received Netconf RPC-Reply\n{}", rpcReply);


### PR DESCRIPTION
- This will (supposed to) allow the session to never timeout.
- I tested this while using the `subscribe` feature and was able to keep the session going and going.
- (I can supply my test, though its rather specific to my set up. Didn't mock stuff out)
- Without a timeout of 0, the session would end on me.