### PR TITLE
edits for default xml envelope

### DIFF
--- a/src/main/java/net/juniper/netconf/Device.java
+++ b/src/main/java/net/juniper/netconf/Device.java
@@ -997,4 +997,3 @@ public class Device implements AutoCloseable {
     }
 
 }
-

--- a/src/main/java/net/juniper/netconf/Device.java
+++ b/src/main/java/net/juniper/netconf/Device.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -961,6 +962,38 @@ public class Device implements AutoCloseable {
      */
     public String getLastRPCReply() {
         return this.netconfSession.getLastRPCReply();
+    }
+
+    /**
+     * Creates a new RPC attribute for use in the default rpc xml envelope used in all rpc executions. Setting
+     * the "xmlns" attribute will override the default namespace attribute, otherwise the value in
+     * NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0 will be used as the default namespace.
+     *
+     * @param name The name of the new RPC attribute.
+     * @param value The value of the new RPC attribute.
+     * @throws NullPointerException If the device connection has not been made yet.
+     */
+    public void createRPCAttribute(String name, String value) {
+        this.netconfSession.addRPCAttribute(name, value);
+    }
+
+    /**
+     * Removes an RPC attribute from the default rpc xml envelope used in all rpc executions.
+     *
+     * @return The value of the removed attribute.
+     * @throws NullPointerException If the device connection has not been made yet.
+     */
+    public String removeRPCAttribute(String name) {
+        return this.netconfSession.removeRPCAttribute(name);
+    }
+
+    /**
+     * Clears all the RPC attributes from the default rpc xml envelope used in all rpc executions. The default namespace
+     * value NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0 will still be present in the xml envelope.
+     */
+    public void clearRPCAttributes() {
+        if(this.netconfSession != null)
+            this.netconfSession.removeAllRPCAttributes();
     }
 
 }

--- a/src/main/java/net/juniper/netconf/NetconfSession.java
+++ b/src/main/java/net/juniper/netconf/NetconfSession.java
@@ -14,7 +14,6 @@ import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSchException;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
@@ -32,7 +31,10 @@ import java.net.SocketTimeoutException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -65,7 +67,8 @@ public class NetconfSession {
     private final int commandTimeout;
     private final int pauseTimeout;
 
-    private final HashMap<String, String> rpcAttributes = new HashMap<>();
+    private final Map<String, String> rpcAttrMap = new HashMap<>();
+    private String rpcAttributes;
 
     private int messageId = 0;
     // Bigger than inner buffer in BufferReader class
@@ -153,30 +156,38 @@ public class NetconfSession {
     private BufferedReader getRpcReplyRunning(String rpc) throws IOException {
         // RFC conformance for XML type, namespaces and message ids for RPCs
         messageId++;
-        if(rpcAttributes.isEmpty())
-            rpc = rpc.replace("<rpc>", "<rpc xmlns=\"" + NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0 + "\" message-id=\"" + messageId + "\">").trim();
-        else {
-            StringBuilder attributes = new StringBuilder();
-            boolean defaultNamespaceSet = false;
-            for (Map.Entry<String, String> attribute : rpcAttributes.entrySet()) {
-                attributes.append(String.format(" %1s=\"%2s\"", attribute.getKey(), attribute.getValue()));
-                if (attribute.getKey().equals("xmlns"))
-                    defaultNamespaceSet = true;
-            }
-            if (!defaultNamespaceSet)
-                attributes.append(" xmlns=\""+NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0+"\"");
-            rpc = rpc.replace("<rpc>", "<rpc " + attributes + " message-id=\"" + messageId + "\">").trim();
-        }
+        rpc = rpc.replace("<rpc>", "<rpc" + getRpcAttributes() + " message-id=\"" + messageId + "\">").trim();
         if (!rpc.contains(NetconfConstants.XML_VERSION)) {
             rpc = NetconfConstants.XML_VERSION + rpc;
         }
-
         // writing the rpc to the device
         log.debug("Sending Netconf RPC\n{}", rpc);
         stdOutStreamToDevice.write(rpc.getBytes(Charsets.UTF_8));
         stdOutStreamToDevice.flush();
         return new BufferedReader(
                 new InputStreamReader(stdInStreamFromDevice, Charsets.UTF_8));
+    }
+
+    /**
+     * Gets the current rpc attribute string. If the rpc attribute string is not yet generated or has been reset then
+     * we generate rpc attributes from the RPC Attribute Map.
+     *
+     * @return The attribute set XML formatted into a string.
+     */
+    public String getRpcAttributes() {
+        if(rpcAttributes == null) {
+            StringBuilder attributes = new StringBuilder();
+            boolean useDefaultNamespace = true;
+            for (Map.Entry<String, String> attribute : rpcAttrMap.entrySet()) {
+                attributes.append(String.format(" %1s=\"%2s\"", attribute.getKey(), attribute.getValue()));
+                if ("xmlns".equals(attribute.getKey()))
+                    useDefaultNamespace = false;
+            }
+            if (useDefaultNamespace)
+                attributes.append(" xmlns=\"" + NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0 + "\"");
+            rpcAttributes = attributes.toString();
+        }
+        return rpcAttributes;
     }
 
 
@@ -927,31 +938,36 @@ public class NetconfSession {
     }
 
     /**
-     * Adds an Attribute to the set of RPC attributes used in the RPC XML envelope.
+     * Adds an Attribute to the set of RPC attributes used in the RPC XML envelope. Resets the rpcAttributes value
+     * to null for generation on the next request.
      *
      * @param name The attribute name for the new attribute.
      * @param value The attribute value for the new attribute.
      */
     public void addRPCAttribute(String name, String value) {
-        rpcAttributes.put(name, value);
+        rpcAttrMap.put(name, value);
+        rpcAttributes = null;
     }
 
     /**
-     * Removes an attribute from the set of RPC attributes used in the RPC XML envelope.
+     * Removes an attribute from the set of RPC attributes used in the RPC XML envelope. Resets the rpcAttributes value
+     * to null for generation on the next request.
      *
      * @param name The attribute name to be removed.
      *
      * @return The value of the removed attribute.
      */
     public String removeRPCAttribute (String name) {
-        return rpcAttributes.remove(name);
+        rpcAttributes = null;
+        return rpcAttrMap.remove(name);
     }
 
     /**
      * Clears all the RPC attributes from the set of RPC attributes used in the RPC XML envelope. The set will be empty
-     * after this call returns.
+     * after this call returns. Resets the rpcAttributes value to null for generation on the next request.
      */
     public void removeAllRPCAttributes() {
-        rpcAttributes.clear();
+        rpcAttrMap.clear();
+        rpcAttributes = null;
     }
 }


### PR DESCRIPTION
Added some methods for overriding the default XML envelope attributes. Just a few simple setters and getters. If nothing ever gets set then the current envelope remains the same. Use is fairly straightforward,
``` java
device.connect();
device.createRPCAttribute("attribute_1_name", "attribute_1_value");
device.createRPCAttribute("attribute_2_name", "attribute_2_value");
device.removeRPCAttribute("attribute_1_name");
device.clearRPCAttributes();
```
Here is an example of the XML envelope if you overload the "xmlns" attribute and set an additional custom one.
``` xml
<?xml version="1.0" encoding="utf-8"?>
<rpc  xmlns="my_overridden_namespace_value" custom_attr="custom_attr_value" message-id="2">
</rpc>
]]>]]>
```