### PR TITLE
Allow for no filter segment to getRunningConfig.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.juniper.netconf</groupId>
     <artifactId>netconf-java</artifactId>
-    <version>2.1.1.1</version>
+    <version>2.1.1.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.juniper.netconf</groupId>
     <artifactId>netconf-java</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.1.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/net/juniper/netconf/Device.java
+++ b/src/main/java/net/juniper/netconf/Device.java
@@ -15,6 +15,7 @@ import com.jcraft.jsch.Session;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
@@ -55,6 +56,7 @@ import java.util.List;
  */
 @Slf4j
 @Getter
+@ToString
 public class Device implements AutoCloseable {
 
     private static final int DEFAULT_NETCONF_PORT = 830;

--- a/src/main/java/net/juniper/netconf/NetconfSession.java
+++ b/src/main/java/net/juniper/netconf/NetconfSession.java
@@ -286,9 +286,7 @@ public class NetconfSession {
                 "<source>" +
                 "<" + target + "/>" +
                 "</source>" +
-                "<filter type=\"subtree\">" +
-                configTree +
-                "</filter>" +
+                (configTree == null ? "" : "<filter type=\"subtree\">" + configTree + "</filter>") +
                 "</get-config>" +
                 "</rpc>" +
                 NetconfConstants.DEVICE_PROMPT;


### PR DESCRIPTION
- I found this needed in my set up. For some reason, when I left confgtree blank, the default `EMPTY_CONFIGURATION_TAG` (which is `<configuration></configuration>`) did not return anything
- However, when I fully ensured the `<filter ... >` section is removed, I got the data I was seeking.
- I'm not sure if this is some nuance with my netopeer2 set up, but until I removed that filter section, I got not data back.

Now, I don't think this code is in a final state! I see it as the start of a converstaion. I'm not sure how you'd want to implement this, perhaps there should be a pure `getRunningConfigNoFilter` function that will take on this feature more clearly than sending in a `null` value manually. 