### PR TITLE
Fixed test error due to difference in line endings. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.juniper.netconf</groupId>
     <artifactId>netconf-java</artifactId>
-    <version>2.1.1.2</version>
+    <version>2.1.1.3</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -151,7 +151,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <configuration>
                     <show>public</show>
                 </configuration>
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>r05</version>
+            <version>30.0-jre</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/net/juniper/netconf/NetconfConstants.java
+++ b/src/main/java/net/juniper/netconf/NetconfConstants.java
@@ -33,5 +33,6 @@ public class NetconfConstants {
 
     public static final String EMPTY_LINE = "";
     public static final String LF = "\n";
+    public static final String CR = "\r";
 
 }

--- a/src/main/java/net/juniper/netconf/XML.java
+++ b/src/main/java/net/juniper/netconf/XML.java
@@ -391,7 +391,7 @@ public class XML {
                     return null;
                 }
             }        }
-        if (nextElement == null) {
+        if (nextElement == null || nextElement.getFirstChild() == null || nextElement.getFirstChild().getNodeValue()== null) {
             return null;
         }
         String value = nextElement.getFirstChild().getNodeValue();


### PR DESCRIPTION
- Fixed https://github.com/Juniper/netconf-java/issues/44
- Updated Guava dependency, as per CVE https://github.com/advisories/GHSA-5mg8-w23w-74h3
- Minor test change to remove unnecessary .toString() on a method that is expected to throw before .toString is called.