### PR TITLE
Add namespace aware parsing for <hello>

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# See https://editorconfig.org/
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = false
+max_line_length = 120
+tab_width = 4
+
+[{*.bat,*.cmd}]
+end_of_line = crlf
+
+[*.java]
+ij_java_blank_lines_after_imports = 1
+ij_java_blank_lines_before_imports = 1
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_imports_layout = *,|,javax.**,java.**,|,$*
+ij_java_layout_static_imports_separately = true
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_use_single_class_imports = true

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.juniper.netconf</groupId>
     <artifactId>netconf-java</artifactId>
-    <version>2.1.1.4</version>
+    <version>2.1.1.5</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -230,6 +230,13 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>30.0-jre</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-assertj</artifactId>
+            <version>2.8.2</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/net/juniper/netconf/element/Hello.java
+++ b/src/main/java/net/juniper/netconf/element/Hello.java
@@ -1,0 +1,165 @@
+package net.juniper.netconf.element;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import net.juniper.netconf.NetconfConstants;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
+
+/**
+ * Class to represent a NETCONF hello element - https://datatracker.ietf.org/doc/html/rfc6241#section-8.1
+ */
+@Data
+@Slf4j
+public class Hello {
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private final Document document;
+
+    @ToString.Exclude
+    private final String xml;
+
+    private final String sessionId;
+
+    @Singular("capability")
+    private final List<String> capabilities;
+
+    public boolean hasCapability(final String capability) {
+        return capabilities.contains(capability);
+    }
+
+    public String toXML() {
+        return xml;
+    }
+
+    /**
+     * Creates a Hello object based on the supplied XML.
+     *
+     * @param xml The XML of the NETCONF &lt;hello&gt;
+     * @return an new, immutable, Hello object.
+     * @throws ParserConfigurationException If the XML parser cannot be created
+     * @throws IOException                  If the XML cannot be read
+     * @throws SAXException                 If the XML cannot be parsed
+     * @throws XPathExpressionException     If there is a problem in the parsing expressions
+     */
+    public static Hello from(final String xml)
+            throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
+
+        final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        final Document document = documentBuilderFactory.newDocumentBuilder()
+                .parse(new InputSource(new StringReader(xml)));
+        final XPath xPath = XPathFactory.newInstance().newXPath();
+        final String sessionId = xPath.evaluate("/*[namespace-uri()='urn:ietf:params:xml:ns:netconf:base:1.0' and local-name()='hello']/*[namespace-uri()='urn:ietf:params:xml:ns:netconf:base:1.0' and local-name()='session-id']", document);
+        final HelloBuilder builder = Hello.builder()
+                .originalDocument(document)
+                .sessionId(sessionId);
+        final NodeList capabilities = (NodeList) xPath.evaluate("/*[namespace-uri()='urn:ietf:params:xml:ns:netconf:base:1.0' and local-name()='hello']/*[namespace-uri()='urn:ietf:params:xml:ns:netconf:base:1.0' and local-name()='capabilities']/*[namespace-uri()='urn:ietf:params:xml:ns:netconf:base:1.0' and local-name()='capability']", document, XPathConstants.NODESET);
+        for (int i = 0; i < capabilities.getLength(); i++) {
+            final Node node = capabilities.item(i);
+            builder.capability(node.getTextContent());
+        }
+        final Hello hello = builder.build();
+        if (log.isInfoEnabled()) {
+            log.info("hello is: {}", hello.toXML());
+        }
+        return hello;
+    }
+
+    @Builder
+    private Hello(
+            final Document originalDocument,
+            final String namespacePrefix,
+            final String sessionId,
+            @Singular("capability") final List<String> capabilities) {
+        this.sessionId = sessionId;
+        this.capabilities = capabilities;
+        if (originalDocument != null) {
+            this.document = originalDocument;
+        } else {
+            this.document = createDocument(namespacePrefix, sessionId, capabilities);
+        }
+        this.xml = createXml(document);
+    }
+
+    private static Document createDocument(
+            final String namespacePrefix,
+            final String sessionId,
+            final List<String> capabilities) {
+
+        final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        final Document createdDocument;
+        try {
+            createdDocument = documentBuilderFactory.newDocumentBuilder().newDocument();
+        } catch (final ParserConfigurationException e) {
+            throw new IllegalStateException("Unable to create document builder", e);
+        }
+
+        final Element helloElement
+                = createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "hello");
+        helloElement.setPrefix(namespacePrefix);
+        createdDocument.appendChild(helloElement);
+
+        final Element capabilitiesElement
+                = createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "capabilities");
+        capabilitiesElement.setPrefix(namespacePrefix);
+        capabilities.forEach(capability -> {
+            final Element capabilityElement =
+                    createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "capability");
+            capabilityElement.setTextContent(capability);
+            capabilityElement.setPrefix(namespacePrefix);
+            capabilitiesElement.appendChild(capabilityElement);
+        });
+        helloElement.appendChild(capabilitiesElement);
+
+        if (sessionId != null) {
+            final Element sessionIdElement
+                    = createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "session-id");
+            sessionIdElement.setPrefix(namespacePrefix);
+            sessionIdElement.setTextContent(sessionId);
+            helloElement.appendChild(sessionIdElement);
+        }
+        return createdDocument;
+    }
+
+    private static String createXml(final Document document) {
+        try {
+            final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            final Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            final StringWriter stringWriter = new StringWriter();
+            transformer.transform(new DOMSource(document), new StreamResult(stringWriter));
+            return stringWriter.toString();
+        } catch (final TransformerException e) {
+            throw new IllegalStateException("Unable to transform document to XML", e);
+        }
+    }
+
+}

--- a/src/test/java/net/juniper/netconf/DeviceTest.java
+++ b/src/test/java/net/juniper/netconf/DeviceTest.java
@@ -5,8 +5,16 @@ import com.jcraft.jsch.HostKeyRepository;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.xmlunit.assertj.XmlAssert;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,7 +30,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-
 @Category(Test.class)
 public class DeviceTest {
 
@@ -31,7 +38,25 @@ public class DeviceTest {
     private static final String TEST_PASSWORD = "password";
     private static final int DEFAULT_NETCONF_PORT = 830;
     private static final int DEFAULT_TIMEOUT = 5000;
-    public static final String SUBSYSTEM = "subsystem";
+    private static final String SUBSYSTEM = "subsystem";
+    private static final String HELLO_WITH_DEFAULT_CAPABILITIES = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        + "<hello xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">\n"
+        + "<capabilities>\n"
+        + "<capability>urn:ietf:params:netconf:base:1.0</capability>\n"
+        + "<capability>urn:ietf:params:netconf:base:1.0#candidate</capability>\n"
+        + "<capability>urn:ietf:params:netconf:base:1.0#confirmed-commit</capability>\n"
+        + "<capability>urn:ietf:params:netconf:base:1.0#validate</capability>\n"
+        + "<capability>urn:ietf:params:netconf:base:1.0#url?protocol=http,ftp,file</capability>\n"
+        + "</capabilities>\n"
+        + "</hello>";
+    private static final String HELLO_WITH_BASE_CAPABILITIES = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        + "<hello xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">\n"
+        + "<capabilities>\n"
+        + "<capability>urn:ietf:params:netconf:base:1.0</capability>\n"
+        + "</capabilities>\n"
+        + "</hello>";
+
+    private ByteArrayOutputStream outputStream;
 
     private Device createTestDevice() throws NetconfException {
         return Device.builder()
@@ -40,6 +65,11 @@ public class DeviceTest {
                 .password(TEST_PASSWORD)
                 .strictHostKeyChecking(false)
                 .build();
+    }
+
+    @Before
+    public void setUp() {
+        outputStream = new ByteArrayOutputStream();
     }
 
     @Test
@@ -78,6 +108,7 @@ public class DeviceTest {
                 .build()) {
             device.connect();
         } catch (NetconfException e) {
+            // Do nothing
         }
 
         verify(channel).connect(eq(DEFAULT_TIMEOUT));
@@ -122,5 +153,72 @@ public class DeviceTest {
     public void GIVEN_newDevice_WHEN_checkIfConnected_THEN_returnFalse() throws NetconfException {
         Device device = createTestDevice();
         assertFalse(device.isConnected());
+    }
+
+    @Test
+    public void GIVEN_newDevice_WHEN_connect_THEN_sendHelloWithDefaultCapabilities() throws Exception {
+
+        final JSch sshClient = givenConnectingSshClient();
+
+        final Device device = Device.builder()
+            .sshClient(sshClient)
+            .hostName(TEST_HOSTNAME)
+            .userName(TEST_USERNAME)
+            .password(TEST_PASSWORD)
+            .strictHostKeyChecking(false)
+            .build();
+        device.connect();
+
+        final String message = outputStream.toString();
+        assertThat(message).endsWith(NetconfConstants.DEVICE_PROMPT);
+        final String hello = message.substring(0, message.length() - NetconfConstants.DEVICE_PROMPT.length());
+        XmlAssert.assertThat(hello)
+            .and(HELLO_WITH_DEFAULT_CAPABILITIES)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+
+    @Test
+    public void GIVEN_newDevice_WHEN_connect_THEN_sendHelloWithCustomCapabilities() throws Exception {
+
+        final JSch sshClient = givenConnectingSshClient();
+
+        final Device device = Device.builder()
+            .sshClient(sshClient)
+            .netconfCapabilities(Collections.singletonList(NetconfConstants.URN_IETF_PARAMS_NETCONF_BASE_1_0))
+            .hostName(TEST_HOSTNAME)
+            .userName(TEST_USERNAME)
+            .password(TEST_PASSWORD)
+            .strictHostKeyChecking(false)
+            .build();
+        device.connect();
+
+        final String message = outputStream.toString();
+        assertThat(message).endsWith(NetconfConstants.DEVICE_PROMPT);
+        final String hello = message.substring(0, message.length() - NetconfConstants.DEVICE_PROMPT.length());
+        XmlAssert.assertThat(hello)
+            .and(HELLO_WITH_BASE_CAPABILITIES)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+
+    private JSch givenConnectingSshClient() throws IOException, JSchException {
+        final Session sshSession = mock(Session.class);
+        when(sshSession.isConnected())
+            .thenReturn(true);
+        final ChannelSubsystem sshChannel = mock(ChannelSubsystem.class);
+        when(sshChannel.getOutputStream())
+            .thenReturn(outputStream);
+        final ByteArrayInputStream is = new ByteArrayInputStream(
+            ("<hello/>" + NetconfConstants.DEVICE_PROMPT)
+                .getBytes(StandardCharsets.UTF_8));
+        when(sshChannel.getInputStream())
+            .thenReturn(is);
+        when(sshSession.openChannel(eq(SUBSYSTEM)))
+            .thenReturn(sshChannel);
+        final JSch sshClient = mock(JSch.class);
+        when(sshClient.getSession(eq(TEST_USERNAME), eq(TEST_HOSTNAME), eq(DEFAULT_NETCONF_PORT)))
+            .thenReturn(sshSession);
+        return sshClient;
     }
 }

--- a/src/test/java/net/juniper/netconf/element/HelloTest.java
+++ b/src/test/java/net/juniper/netconf/element/HelloTest.java
@@ -1,0 +1,107 @@
+package net.juniper.netconf.element;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.xmlunit.assertj.XmlAssert;
+
+public class HelloTest {
+
+    // Samples taken from https://www.juniper.net/documentation/us/en/software/junos/netconf/topics/concept/netconf-session-rfc-compliant.html
+    public static final String HELLO_WITHOUT_NAMESPACE = ""
+            + "<hello xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">\n"
+            + "  <capabilities>\n"
+            + "    <capability>urn:ietf:params:netconf:base:1.0</capability>\n"
+            + "    <capability>urn:ietf:params:netconf:base:1.0#candidate</capability>\n"
+            + "    <capability>urn:ietf:params:netconf:base:1.0#confirmed-commit</capability>\n"
+            + "    <capability>urn:ietf:params:netconf:base:1.0#validate</capability>\n"
+            + "    <capability>urn:ietf:params:netconf:base:1.0#url?protocol=http,ftp,file</capability>\n"
+            + "  </capabilities>\n"
+            + "  <session-id>27700</session-id>\n"
+            + "</hello>";
+
+    public static final String HELLO_WITH_NAMESPACE = "" +
+            "<nc:hello xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">\n"
+            + "  <nc:capabilities>\n"
+            + "    <nc:capability>urn:ietf:params:netconf:base:1.0</nc:capability>\n"
+            + "    <nc:capability>urn:ietf:params:netconf:base:1.0#candidate</nc:capability>\n"
+            + "    <nc:capability>urn:ietf:params:netconf:base:1.0#confirmed-commit</nc:capability>\n"
+            + "    <nc:capability>urn:ietf:params:netconf:base:1.0#validate</nc:capability>\n"
+            + "    <nc:capability>urn:ietf:params:netconf:base:1.0#url?protocol=http,ftp,file</nc:capability>\n"
+            + "  </nc:capabilities>\n"
+            + "  <nc:session-id>27703</nc:session-id>\n"
+            + "</nc:hello>";
+
+    @Test
+    public void willCreateAnObjectFromPacketWithoutNamespace() throws Exception {
+
+        final Hello hello = Hello.from(HELLO_WITHOUT_NAMESPACE);
+
+        assertThat(hello.getSessionId())
+                .isEqualTo("27700");
+        assertThat(hello.getCapabilities())
+                .containsExactly(
+                        "urn:ietf:params:netconf:base:1.0",
+                        "urn:ietf:params:netconf:base:1.0#candidate",
+                        "urn:ietf:params:netconf:base:1.0#confirmed-commit",
+                        "urn:ietf:params:netconf:base:1.0#validate",
+                        "urn:ietf:params:netconf:base:1.0#url?protocol=http,ftp,file");
+        assertThat(hello.hasCapability("urn:ietf:params:netconf:base:1.0#candidate"))
+                .isTrue();
+    }
+
+    @Test
+    public void willCreateAnObjectFromPacketWithNamespace() throws Exception {
+
+        final Hello hello = Hello.from(HELLO_WITH_NAMESPACE);
+
+        assertThat(hello.getSessionId())
+                .isEqualTo("27703");
+        assertThat(hello.getCapabilities())
+                .containsExactly(
+                        "urn:ietf:params:netconf:base:1.0",
+                        "urn:ietf:params:netconf:base:1.0#candidate",
+                        "urn:ietf:params:netconf:base:1.0#confirmed-commit",
+                        "urn:ietf:params:netconf:base:1.0#validate",
+                        "urn:ietf:params:netconf:base:1.0#url?protocol=http,ftp,file");
+        assertThat(hello.hasCapability("urn:ietf:params:netconf:base:1.0#candidate"))
+                .isTrue();
+    }
+
+    @Test
+    public void willCreateXmlFromAnObject() {
+
+        final Hello hello = Hello.builder()
+                .capability("urn:ietf:params:netconf:base:1.0")
+                .capability("urn:ietf:params:netconf:base:1.0#candidate")
+                .capability("urn:ietf:params:netconf:base:1.0#confirmed-commit")
+                .capability("urn:ietf:params:netconf:base:1.0#validate")
+                .capability("urn:ietf:params:netconf:base:1.0#url?protocol=http,ftp,file")
+                .sessionId("27700")
+                .build();
+
+        XmlAssert.assertThat(hello.toXML())
+                .and(HELLO_WITHOUT_NAMESPACE)
+                .ignoreWhitespace()
+                .areIdentical();
+    }
+
+    @Test
+    public void willCreateXmlWithNamespaceFromAnObject() {
+
+        final Hello hello = Hello.builder()
+                .namespacePrefix("nc")
+                .capability("urn:ietf:params:netconf:base:1.0")
+                .capability("urn:ietf:params:netconf:base:1.0#candidate")
+                .capability("urn:ietf:params:netconf:base:1.0#confirmed-commit")
+                .capability("urn:ietf:params:netconf:base:1.0#validate")
+                .capability("urn:ietf:params:netconf:base:1.0#url?protocol=http,ftp,file")
+                .sessionId("27703")
+                .build();
+
+        XmlAssert.assertThat(hello.toXML())
+                .and(HELLO_WITH_NAMESPACE)
+                .ignoreWhitespace()
+                .areIdentical();
+    }
+}


### PR DESCRIPTION
This PR is part of the fix for https://github.com/Juniper/netconf-java/issues/49

It
a) Introduces a new Hello.java that represents the `<hello>` NETCONF element. This is generated by using a namespace aware XML parser, so copes with the "nc:" prefix discussed in the ticket
b) uses the Hello.java to both generate the client `<hello>` and parse the server `<hello>`. This means that the library now will correctly identify the session id when the server is using a nc: prefix. Note that before making a changes, I wrote tests around both sending the client `<hello>` and receiving the server `<hello>` - so I'm confident it's not had an deleterious effects. I've also tested it by accessing a local device - and is working OK. 

Note; this is only **_part_** of the fix for the issue. The `<rpc-reply>` element needs similar work before the namespace prefix issue can be fully resolved. 
- I like to keep each PR as small as possible, to make it clearer what's going on, and
- The `<rpc-reply>` element is going to be more complex - before I spent lots of effort on it I wanted to have some confidence that my mechanism for solving it would be acceptable

So any feedback grateful appreciated!