### PR TITLE
Add namespace-aware parsing for rpc-reply

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.juniper.netconf</groupId>
     <artifactId>netconf-java</artifactId>
-    <version>2.1.1.5</version>
+    <version>2.1.1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -208,14 +208,8 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.24.0</version>
+            <version>3.11.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/net/juniper/netconf/Device.java
+++ b/src/main/java/net/juniper/netconf/Device.java
@@ -170,7 +170,7 @@ public class Device implements AutoCloseable {
         return Hello.builder()
             .capabilities(capabilities)
             .build()
-            .toXML()
+            .getXml()
             + NetconfConstants.DEVICE_PROMPT;
     }
 

--- a/src/main/java/net/juniper/netconf/element/AbstractNetconfElement.java
+++ b/src/main/java/net/juniper/netconf/element/AbstractNetconfElement.java
@@ -1,0 +1,107 @@
+package net.juniper.netconf.element;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import net.juniper.netconf.NetconfConstants;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+
+import static java.lang.String.format;
+
+@Value
+@NonFinal
+public abstract class AbstractNetconfElement {
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    Document document;
+
+    @ToString.Exclude
+    String xml;
+
+    protected AbstractNetconfElement(final Document document) {
+        this.document = document;
+        this.xml = createXml(document);
+    }
+
+    protected static Document createBlankDocument() {
+        try {
+            return createDocumentBuilderFactory().newDocumentBuilder().newDocument();
+        } catch (final ParserConfigurationException e) {
+            throw new IllegalStateException("Unable to create document builder", e);
+        }
+    }
+
+    protected static DocumentBuilderFactory createDocumentBuilderFactory() {
+        final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        return documentBuilderFactory;
+    }
+
+    protected static String createXml(final Document document) {
+        try {
+            final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            final Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            final StringWriter stringWriter = new StringWriter();
+            transformer.transform(new DOMSource(document), new StreamResult(stringWriter));
+            return stringWriter.toString();
+        } catch (final TransformerException e) {
+            throw new IllegalStateException("Unable to transform document to XML", e);
+        }
+    }
+
+    protected static String getXpathFor(final String elementName) {
+        return format("/*[namespace-uri()='urn:ietf:params:xml:ns:netconf:base:1.0' and local-name()='%s']", elementName);
+    }
+
+    protected static Element appendElementWithText(
+        final Document document,
+        final Element parentElement,
+        final String namespacePrefix,
+        final String elementName,
+        final String text) {
+
+        if (text != null) {
+            final Element childElement = document.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, elementName);
+            childElement.setPrefix(namespacePrefix);
+            childElement.setTextContent(text);
+            parentElement.appendChild(childElement);
+            return childElement;
+        } else {
+            return null;
+        }
+    }
+
+    protected static String getAttribute(final Element element, final String attributeName) {
+        if (element != null && element.hasAttribute(attributeName)) {
+            return element.getAttribute(attributeName);
+        } else {
+            return null;
+        }
+    }
+
+    protected static String getTextContent(final Element element) {
+        if (element == null) {
+            return null;
+        } else {
+            return trim(element.getTextContent());
+        }
+    }
+
+    protected static String trim(final String string) {
+        return string == null ? null : string.trim();
+    }
+}

--- a/src/main/java/net/juniper/netconf/element/RpcError.java
+++ b/src/main/java/net/juniper/netconf/element/RpcError.java
@@ -1,0 +1,110 @@
+package net.juniper.netconf.element;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+/**
+ * Class to represent a NETCONF rpc-error element - https://datatracker.ietf.org/doc/html/rfc6241#section-4.3
+ */
+@Value
+@Builder
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class RpcError {
+
+    ErrorType errorType;
+    ErrorTag errorTag;
+    ErrorSeverity errorSeverity;
+    String errorPath;
+    String errorMessage;
+    String errorMessageLanguage;
+    RpcErrorInfo errorInfo;
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum ErrorType {
+        TRANSPORT("transport"), RPC("rpc"), PROTOCOL("protocol"), APPLICATION("application");
+
+        private final String textContent;
+
+        public static ErrorType from(final String textContent) {
+            for (final ErrorType errorType : ErrorType.values()) {
+                if (errorType.textContent.equals(textContent)) {
+                    return errorType;
+                }
+            }
+            return null;
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum ErrorTag {
+        IN_USE("in-use"),
+        INVALID_VALUE("invalid-value"),
+        TOO_BIG("too-big"),
+        MISSING_ATTRIBUTE("missing-attribute"),
+        BAD_ATTRIBUTE("bad-attribute"),
+        UNKNOWN_ATTRIBUTE("unknown-attribute"),
+        MISSING_ELEMENT("missing-element"),
+        BAD_ELEMENT("bad-element"),
+        UNKNOWN_ELEMENT("unknown-element"),
+        UNKNOWN_NAMESPACE("unknown-namespace"),
+        ACCESS_DENIED("access-denied"),
+        LOCK_DENIED("lock-denied"),
+        DATA_EXISTS("data-exists"),
+        DATA_MISSING("data-missing"),
+        OPERATION_NOT_SUPPORTED("operation-not-supported"),
+        OPERATION_FAILED("operation-failed"),
+        PARTIAL_OPERATION("partial-operation"),
+        MALFORMED_MESSAGE("malformed-message");
+
+        private final String textContent;
+
+        public static ErrorTag from(final String textContent) {
+            for (final ErrorTag errorTag : ErrorTag.values()) {
+                if (errorTag.textContent.equals(textContent)) {
+                    return errorTag;
+                }
+            }
+            return null;
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum ErrorSeverity {
+        ERROR("error"), WARNING("warning");
+
+        private final String textContent;
+
+        public static ErrorSeverity from(final String textContent) {
+            for (final ErrorSeverity errorSeverity : ErrorSeverity.values()) {
+                if (errorSeverity.textContent.equals(textContent)) {
+                    return errorSeverity;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Class to represent a NETCONF rpc error-info element - https://datatracker.ietf.org/doc/html/rfc6241#section-4.3
+     */
+    @Value
+    @Builder
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class RpcErrorInfo {
+
+        String badAttribute;
+        String badElement;
+        String badNamespace;
+        String sessionId;
+        String okElement;
+        String errElement;
+        String noOpElement;
+
+    }
+}

--- a/src/main/java/net/juniper/netconf/element/RpcReply.java
+++ b/src/main/java/net/juniper/netconf/element/RpcReply.java
@@ -1,0 +1,220 @@
+package net.juniper.netconf.element;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import lombok.extern.slf4j.Slf4j;
+import net.juniper.netconf.NetconfConstants;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Optional.ofNullable;
+
+/**
+ * Class to represent a NETCONF rpc-reply element - https://datatracker.ietf.org/doc/html/rfc6241#section-4.2
+ */
+@Slf4j
+@Value
+@NonFinal
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class RpcReply extends AbstractNetconfElement {
+
+    protected static final String XPATH_RPC_REPLY = getXpathFor("rpc-reply");
+    private static final String XPATH_RPC_REPLY_OK = XPATH_RPC_REPLY + getXpathFor("ok");
+    private static final String XPATH_RPC_REPLY_ERROR = XPATH_RPC_REPLY + getXpathFor("rpc-error");
+    private static final String XPATH_RPC_REPLY_ERROR_TYPE = getXpathFor("error-type");
+    private static final String XPATH_RPC_REPLY_ERROR_TAG = getXpathFor("error-tag");
+    private static final String XPATH_RPC_REPLY_ERROR_SEVERITY = getXpathFor("error-severity");
+    private static final String XPATH_RPC_REPLY_ERROR_PATH = getXpathFor("error-path");
+    private static final String XPATH_RPC_REPLY_ERROR_MESSAGE = getXpathFor("error-message");
+    private static final String XPATH_RPC_REPLY_ERROR_INFO = getXpathFor("error-info");
+    private static final String XPATH_RPC_REPLY_ERROR_INFO_BAD_ATTRIBUTE = XPATH_RPC_REPLY_ERROR_INFO + getXpathFor("bad-attribute");
+    private static final String XPATH_RPC_REPLY_ERROR_INFO_BAD_ELEMENT = XPATH_RPC_REPLY_ERROR_INFO + getXpathFor("bad-element");
+    private static final String XPATH_RPC_REPLY_ERROR_INFO_BAD_NAMESPACE = XPATH_RPC_REPLY_ERROR_INFO + getXpathFor("bad-namespace");
+    private static final String XPATH_RPC_REPLY_ERROR_INFO_SESSION_ID = XPATH_RPC_REPLY_ERROR_INFO + getXpathFor("session-id");
+    private static final String XPATH_RPC_REPLY_ERROR_INFO_OK_ELEMENT = XPATH_RPC_REPLY_ERROR_INFO + getXpathFor("ok-element");
+    private static final String XPATH_RPC_REPLY_ERROR_INFO_ERR_ELEMENT = XPATH_RPC_REPLY_ERROR_INFO + getXpathFor("err-element");
+    private static final String XPATH_RPC_REPLY_ERROR_INFO_NO_OP_ELEMENT = XPATH_RPC_REPLY_ERROR_INFO + getXpathFor("noop-element");
+
+    String messageId;
+    boolean ok;
+    List<RpcError> errors;
+
+    public boolean hasErrorsOrWarnings() {
+        return !errors.isEmpty();
+    }
+
+    public boolean hasErrors() {
+        return errors.stream().anyMatch(error -> error.getErrorSeverity() == RpcError.ErrorSeverity.ERROR);
+    }
+
+    public boolean hasWarnings() {
+        return errors.stream().anyMatch(error -> error.getErrorSeverity() == RpcError.ErrorSeverity.WARNING);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends AbstractNetconfElement> T from(final String xml)
+        throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
+
+        final Document document = createDocumentBuilderFactory().newDocumentBuilder()
+            .parse(new InputSource(new StringReader(xml)));
+        final XPath xPath = XPathFactory.newInstance().newXPath();
+
+        final Element loadConfigResultsElement = (Element) xPath.evaluate(RpcReplyLoadConfigResults.XPATH_RPC_REPLY_LOAD_CONFIG_RESULT, document, XPathConstants.NODE);
+        if (loadConfigResultsElement != null) {
+            return (T) RpcReplyLoadConfigResults.from(xml);
+        }
+
+        final Element rpcReplyElement = (Element) xPath.evaluate(XPATH_RPC_REPLY, document, XPathConstants.NODE);
+        final Element rpcReplyOkElement = (Element) xPath.evaluate(XPATH_RPC_REPLY_OK, document, XPathConstants.NODE);
+        final List<RpcError> errorList = getRpcErrors(document, xPath, XPATH_RPC_REPLY_ERROR);
+
+        final RpcReply rpcReply = RpcReply.builder()
+            .messageId(getAttribute(rpcReplyElement, "message-id"))
+            .ok(rpcReplyOkElement != null)
+            .errors(errorList)
+            .originalDocument(document)
+            .build();
+        log.info("rpc-reply is: {}", rpcReply.getXml());
+        return (T) rpcReply;
+    }
+
+    protected static List<RpcError> getRpcErrors(final Document document, final XPath xPath, final String xpathQuery)
+        throws XPathExpressionException {
+        final NodeList errors = (NodeList) xPath.evaluate(xpathQuery, document, XPathConstants.NODESET);
+        final List<RpcError> errorList = new ArrayList<>();
+        for (int i = 1; i <= errors.getLength(); i++) {
+            final String expressionPrefix = String.format("%s[%d]", xpathQuery, i);
+            final String errorType = xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_TYPE, document);
+            final String errorTag = xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_TAG, document);
+            final String errorSeverity = xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_SEVERITY, document);
+            final Element errorMessageElement = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_MESSAGE, document, XPathConstants.NODE);
+            final Element errorPathElement = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_PATH, document, XPathConstants.NODE);
+            final RpcError.RpcErrorBuilder errorBuilder = RpcError.builder()
+                .errorType(RpcError.ErrorType.from(errorType))
+                .errorTag(RpcError.ErrorTag.from(errorTag))
+                .errorSeverity(RpcError.ErrorSeverity.from(errorSeverity))
+                .errorMessage(getTextContent(errorMessageElement))
+                .errorMessageLanguage(getAttribute(errorMessageElement, "xml:lang"))
+                .errorPath(getTextContent(errorPathElement));
+
+            final Element errorInfoElement = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_INFO, document, XPathConstants.NODE);
+            if (errorInfoElement != null) {
+                final Element badAttributeElement = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_INFO_BAD_ATTRIBUTE, document, XPathConstants.NODE);
+                final Element badElementAttribute = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_INFO_BAD_ELEMENT, document, XPathConstants.NODE);
+                final Element badNamespaceElement = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_INFO_BAD_NAMESPACE, document, XPathConstants.NODE);
+                final Element sessionIdElement = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_INFO_SESSION_ID, document, XPathConstants.NODE);
+                final Element okElement = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_INFO_OK_ELEMENT, document, XPathConstants.NODE);
+                final Element errElement = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_INFO_ERR_ELEMENT, document, XPathConstants.NODE);
+                final Element noOpElement = (Element) xPath.evaluate(expressionPrefix + XPATH_RPC_REPLY_ERROR_INFO_NO_OP_ELEMENT, document, XPathConstants.NODE);
+
+                final RpcError.RpcErrorInfo errorInfo = RpcError.RpcErrorInfo.builder()
+                    .badAttribute(getTextContent(badAttributeElement))
+                    .badElement(getTextContent(badElementAttribute))
+                    .badNamespace(getTextContent(badNamespaceElement))
+                    .sessionId(getTextContent(sessionIdElement))
+                    .okElement(getTextContent(okElement))
+                    .errElement(getTextContent(errElement))
+                    .noOpElement(getTextContent(noOpElement))
+                    .build();
+                errorBuilder.errorInfo(errorInfo);
+            }
+            errorList.add(errorBuilder.build());
+        }
+        return errorList;
+    }
+
+    @Builder
+    protected RpcReply(
+        final Document originalDocument,
+        final String namespacePrefix,
+        final String messageId,
+        final boolean ok,
+        @Singular("error") final List<RpcError> errors) {
+        super(getDocument(originalDocument, namespacePrefix, messageId, ok, errors));
+        this.messageId = messageId;
+        this.ok = ok;
+        this.errors = errors;
+    }
+
+    private static Document getDocument(
+        final Document originalDocument,
+        final String namespacePrefix,
+        final String messageId,
+        final boolean ok,
+        final List<RpcError> errors) {
+        if (originalDocument != null) {
+            return originalDocument;
+        } else {
+            return createDocument(namespacePrefix, messageId, ok, errors);
+        }
+    }
+
+    private static Document createDocument(
+        final String namespacePrefix,
+        final String messageId,
+        final boolean ok,
+        final List<RpcError> errors) {
+        final Document createdDocument = createBlankDocument();
+
+        final Element rpcReplyElement = createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "rpc-reply");
+        rpcReplyElement.setPrefix(namespacePrefix);
+        rpcReplyElement.setAttribute("message-id", messageId);
+        createdDocument.appendChild(rpcReplyElement);
+        if (ok) {
+            final Element okElement = createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "ok");
+            okElement.setPrefix(namespacePrefix);
+            rpcReplyElement.appendChild(okElement);
+        }
+        appendErrors(namespacePrefix, errors, createdDocument, rpcReplyElement);
+
+        return createdDocument;
+    }
+
+    protected static void appendErrors(final String namespacePrefix, final List<RpcError> errors, final Document createdDocument, final Element parentElement) {
+        errors.forEach(error -> {
+            final Element errorElement = createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "rpc-error");
+            errorElement.setPrefix(namespacePrefix);
+            parentElement.appendChild(errorElement);
+            ofNullable(error.getErrorType())
+                .ifPresent(errorType-> appendElementWithText(createdDocument, errorElement, namespacePrefix, "error-type", errorType.getTextContent()));
+            ofNullable(error.getErrorTag())
+                .ifPresent(errorTag -> appendElementWithText(createdDocument, errorElement, namespacePrefix, "error-tag", errorTag.getTextContent()));
+            ofNullable(error.getErrorSeverity())
+                .ifPresent(errorSeverity -> appendElementWithText(createdDocument, errorElement, namespacePrefix, "error-severity", errorSeverity.getTextContent()));
+            appendElementWithText(createdDocument, errorElement, namespacePrefix, "error-path", error.getErrorPath());
+            final Element errorMessageElement = appendElementWithText(createdDocument, errorElement, namespacePrefix, "error-message", error.getErrorMessage());
+            ofNullable(error.getErrorMessageLanguage())
+                .ifPresent(errorMessageLanguage -> errorMessageElement.setAttribute("xml:lang", errorMessageLanguage));
+            ofNullable(error.getErrorInfo()).ifPresent(errorInfo -> {
+                final Element errorInfoElement = createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "error-info");
+                errorInfoElement.setPrefix(namespacePrefix);
+                errorElement.appendChild(errorInfoElement);
+                appendElementWithText(createdDocument, errorInfoElement, namespacePrefix, "bad-attribute", errorInfo.getBadAttribute());
+                appendElementWithText(createdDocument, errorInfoElement, namespacePrefix, "bad-element", errorInfo.getBadElement());
+                appendElementWithText(createdDocument, errorInfoElement, namespacePrefix, "bad-namespace", errorInfo.getBadNamespace());
+                appendElementWithText(createdDocument, errorInfoElement, namespacePrefix, "session-id", errorInfo.getSessionId());
+                appendElementWithText(createdDocument, errorInfoElement, namespacePrefix, "ok-element", errorInfo.getOkElement());
+                appendElementWithText(createdDocument, errorInfoElement, namespacePrefix, "err-element", errorInfo.getErrElement());
+                appendElementWithText(createdDocument, errorInfoElement, namespacePrefix, "noop-element", errorInfo.getNoOpElement());
+            });
+        });
+    }
+}

--- a/src/main/java/net/juniper/netconf/element/RpcReplyLoadConfigResults.java
+++ b/src/main/java/net/juniper/netconf/element/RpcReplyLoadConfigResults.java
@@ -1,0 +1,109 @@
+package net.juniper.netconf.element;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import lombok.extern.slf4j.Slf4j;
+import net.juniper.netconf.NetconfConstants;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+
+@Slf4j
+@Value
+@NonFinal
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class RpcReplyLoadConfigResults extends RpcReply {
+
+    static final String XPATH_RPC_REPLY_LOAD_CONFIG_RESULT = RpcReply.XPATH_RPC_REPLY + "/*[local-name()='load-configuration-results']";
+    private static final String XPATH_RPC_REPLY_LOAD_CONFIG_RESULT_OK = XPATH_RPC_REPLY_LOAD_CONFIG_RESULT + getXpathFor("ok");
+    private static final String XPATH_RPC_REPLY_LOAD_CONFIG_RESULT_ERROR = XPATH_RPC_REPLY_LOAD_CONFIG_RESULT + getXpathFor("rpc-error");
+
+    String action;
+
+    public static RpcReplyLoadConfigResults from(final String xml)
+        throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
+
+        final Document document = createDocumentBuilderFactory().newDocumentBuilder()
+            .parse(new InputSource(new StringReader(xml)));
+        final XPath xPath = XPathFactory.newInstance().newXPath();
+
+        final Element rpcReplyElement = (Element) xPath.evaluate(XPATH_RPC_REPLY, document, XPathConstants.NODE);
+        final Element loadConfigResultsElement = (Element) xPath.evaluate(RpcReplyLoadConfigResults.XPATH_RPC_REPLY_LOAD_CONFIG_RESULT, document, XPathConstants.NODE);
+        final Element rpcReplyOkElement = (Element) xPath.evaluate(XPATH_RPC_REPLY_LOAD_CONFIG_RESULT_OK, document, XPathConstants.NODE);
+        final List<RpcError> errorList = getRpcErrors(document, xPath, XPATH_RPC_REPLY_LOAD_CONFIG_RESULT_ERROR);
+
+        return RpcReplyLoadConfigResults.loadConfigResultsBuilder()
+            .messageId(getAttribute(rpcReplyElement, "message-id"))
+            .action(getAttribute(loadConfigResultsElement, "action"))
+            .ok(rpcReplyOkElement != null)
+            .errors(errorList)
+            .originalDocument(document)
+            .build();
+    }
+
+    @Builder(builderMethodName = "loadConfigResultsBuilder")
+    private RpcReplyLoadConfigResults(
+        final Document originalDocument,
+        final String namespacePrefix,
+        final String messageId,
+        final String action,
+        final boolean ok,
+        @Singular("error") final List<RpcError> errors) {
+        super(getDocument(originalDocument, namespacePrefix, messageId, action, ok, errors),
+            namespacePrefix, messageId, ok, errors);
+        this.action = action;
+    }
+
+    private static Document getDocument(
+        final Document originalDocument,
+        final String namespacePrefix,
+        final String messageId,
+        final String action,
+        final boolean ok,
+        final List<RpcError> errors) {
+        if (originalDocument != null) {
+            return originalDocument;
+        } else {
+            return createDocument(namespacePrefix, messageId, action, ok, errors);
+        }
+    }
+
+    private static Document createDocument(
+        final String namespacePrefix,
+        final String messageId,
+        final String action,
+        final boolean ok,
+        final List<RpcError> errors) {
+        final Document createdDocument = createBlankDocument();
+        final Element rpcReplyElement = createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "rpc-reply");
+        rpcReplyElement.setPrefix(namespacePrefix);
+        rpcReplyElement.setAttribute("message-id", messageId);
+        createdDocument.appendChild(rpcReplyElement);
+        final Element loadConfigResultsElement = createdDocument.createElement("load-configuration-results");
+        loadConfigResultsElement.setAttribute("action", action);
+        rpcReplyElement.appendChild(loadConfigResultsElement);
+        appendErrors(namespacePrefix, errors, createdDocument, loadConfigResultsElement);
+        if (ok) {
+            final Element okElement = createdDocument.createElementNS(NetconfConstants.URN_XML_NS_NETCONF_BASE_1_0, "ok");
+            okElement.setPrefix(namespacePrefix);
+            loadConfigResultsElement.appendChild(okElement);
+        }
+
+        return createdDocument;
+    }
+}

--- a/src/test/java/net/juniper/netconf/DeviceTest.java
+++ b/src/test/java/net/juniper/netconf/DeviceTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -90,6 +89,7 @@ public class DeviceTest {
     public void GIVEN_sshAvailableNetconfNot_THEN_closeDevice() throws Exception {
         JSch sshClient = mock(JSch.class);
         Session session = mock(Session.class);
+        HostKeyRepository hostKeyRepository = mock(HostKeyRepository.class);
         ChannelSubsystem channel = mock(ChannelSubsystem.class);
         when(channel.isConnected()).thenReturn(false);
 
@@ -98,6 +98,7 @@ public class DeviceTest {
         doThrow(new JSchException("failed to send channel request")).when(channel).connect(eq(DEFAULT_TIMEOUT));
 
         when(sshClient.getSession(eq(TEST_USERNAME), eq(TEST_HOSTNAME), eq(DEFAULT_NETCONF_PORT))).thenReturn(session);
+        when(sshClient.getHostKeyRepository()).thenReturn(hostKeyRepository);
 
         try (Device device = Device.builder()
                 .sshClient(sshClient)
@@ -128,7 +129,7 @@ public class DeviceTest {
 
         verify(sshClient).getSession(eq(TEST_USERNAME), eq(TEST_HOSTNAME), eq(DEFAULT_NETCONF_PORT));
         verify(sshClient).getHostKeyRepository();
-        verify(sshClient).setHostKeyRepository(any(HostKeyRepository.class));
+        verify(sshClient).setHostKeyRepository(hostKeyRepository);
 
         verifyNoMoreInteractions(channel);
         verifyNoMoreInteractions(session);

--- a/src/test/java/net/juniper/netconf/element/HelloTest.java
+++ b/src/test/java/net/juniper/netconf/element/HelloTest.java
@@ -1,9 +1,9 @@
 package net.juniper.netconf.element;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Test;
 import org.xmlunit.assertj.XmlAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HelloTest {
 
@@ -80,7 +80,7 @@ public class HelloTest {
                 .sessionId("27700")
                 .build();
 
-        XmlAssert.assertThat(hello.toXML())
+        XmlAssert.assertThat(hello.getXml())
                 .and(HELLO_WITHOUT_NAMESPACE)
                 .ignoreWhitespace()
                 .areIdentical();
@@ -99,7 +99,7 @@ public class HelloTest {
                 .sessionId("27703")
                 .build();
 
-        XmlAssert.assertThat(hello.toXML())
+        XmlAssert.assertThat(hello.getXml())
                 .and(HELLO_WITH_NAMESPACE)
                 .ignoreWhitespace()
                 .areIdentical();

--- a/src/test/java/net/juniper/netconf/element/RpcReplyLoadConfigResultsTest.java
+++ b/src/test/java/net/juniper/netconf/element/RpcReplyLoadConfigResultsTest.java
@@ -1,0 +1,246 @@
+package net.juniper.netconf.element;
+
+import org.junit.Test;
+import org.xmlunit.assertj.XmlAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RpcReplyLoadConfigResultsTest {
+
+    private static final String LOAD_CONFIG_RESULTS_OK_NO_NAMESPACE = ""
+        + "<rpc-reply xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\"" +
+        "             xmlns:junos=\"http://xml.juniper.net/junos/20.4R0/junos\"" +
+        "             message-id=\"3\">\n" +
+        "    <load-configuration-results action=\"set\">\n" +
+        "        <ok/>\n" +
+        "    </load-configuration-results>\n" +
+        "</rpc-reply>";
+
+    private static final String LOAD_CONFIG_RESULTS_OK_WITH_NAMESPACE = ""
+        + "<nc:rpc-reply xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\"" +
+        "                   xmlns:junos=\"http://xml.juniper.net/junos/20.4R0/junos\"" +
+        "                   message-id=\"4\">\n" +
+        "    <load-configuration-results action=\"set\">\n" +
+        "        <nc:ok/>\n" +
+        "    </load-configuration-results>\n" +
+        "</nc:rpc-reply>";
+
+    private static final String LOAD_CONFIG_RESULTS_ERROR_NO_NAMESPACE = ""
+        + "<rpc-reply xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\"" +
+        "               xmlns:junos=\"http://xml.juniper.net/junos/20.4R0/junos\"\n" +
+        "               message-id=\"5\">\n" +
+        "    <load-configuration-results action=\"set\">\n" +
+        "        <rpc-error>\n" +
+        "            <error-type>protocol</error-type>\n" +
+        "            <error-tag>operation-failed</error-tag>\n" +
+        "            <error-severity>error</error-severity>\n" +
+        "            <error-message>syntax error</error-message>\n" +
+        "            <error-info>\n" +
+        "                <bad-element>foobar</bad-element>\n" +
+        "            </error-info>\n" +
+        "        </rpc-error>\n" +
+        "        <ok/>\n" +
+        "    </load-configuration-results>\n" +
+        "</rpc-reply>\n";
+
+    private static final String LOAD_CONFIG_RESULTS_ERROR_WITH_NAMESPACE = ""
+        + "<nc:rpc-reply xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\"" +
+        "                   xmlns:junos=\"http://xml.juniper.net/junos/20.4R0/junos\"\n" +
+        "                   message-id=\"6\">\n" +
+        "    <load-configuration-results action=\"set\">\n" +
+        "        <nc:rpc-error>\n" +
+        "            <nc:error-type>protocol</nc:error-type>\n" +
+        "            <nc:error-tag>operation-failed</nc:error-tag>\n" +
+        "            <nc:error-severity>error</nc:error-severity>\n" +
+        "            <nc:error-message>syntax error</nc:error-message>\n" +
+        "            <nc:error-info>\n" +
+        "                <nc:bad-element>foobar</nc:bad-element>\n" +
+        "            </nc:error-info>\n" +
+        "        </nc:rpc-error>\n" +
+        "        <nc:ok/>\n" +
+        "    </load-configuration-results>\n" +
+        "</nc:rpc-reply>\n";
+
+    @Test
+    public void willParseAnOkResponseWithNoNamespacePrefix() throws Exception {
+
+        final RpcReplyLoadConfigResults rpcReply = RpcReply.from(LOAD_CONFIG_RESULTS_OK_NO_NAMESPACE);
+
+        assertThat(rpcReply.getMessageId())
+            .isEqualTo("3");
+        assertThat(rpcReply.getAction())
+            .isEqualTo("set");
+        assertThat(rpcReply.isOk())
+            .isTrue();
+        assertThat(rpcReply.hasErrorsOrWarnings())
+            .isFalse();
+        assertThat(rpcReply.hasErrors())
+            .isFalse();
+        assertThat(rpcReply.hasWarnings())
+            .isFalse();
+        assertThat(rpcReply.getErrors())
+            .isEmpty();
+
+    }
+
+    @Test
+    public void willParseAnOkResponseWithNamespacePrefix() throws Exception {
+
+        final RpcReplyLoadConfigResults rpcReply = RpcReply.from(LOAD_CONFIG_RESULTS_OK_WITH_NAMESPACE);
+
+        assertThat(rpcReply.getMessageId())
+            .isEqualTo("4");
+        assertThat(rpcReply.getAction())
+            .isEqualTo("set");
+        assertThat(rpcReply.isOk())
+            .isTrue();
+        assertThat(rpcReply.hasErrorsOrWarnings())
+            .isFalse();
+        assertThat(rpcReply.hasErrors())
+            .isFalse();
+        assertThat(rpcReply.hasWarnings())
+            .isFalse();
+        assertThat(rpcReply.getErrors())
+            .isEmpty();
+
+    }
+
+    @Test
+    public void willParseAnErrorResponseWithoutNamespacePrefix() throws Exception {
+
+        final RpcReplyLoadConfigResults rpcReply = RpcReply.from(LOAD_CONFIG_RESULTS_ERROR_NO_NAMESPACE);
+
+        assertThat(rpcReply.getMessageId())
+            .isEqualTo("5");
+        assertThat(rpcReply.getAction())
+            .isEqualTo("set");
+        assertThat(rpcReply.isOk())
+            .isTrue();
+        assertThat(rpcReply.hasErrorsOrWarnings())
+            .isTrue();
+        assertThat(rpcReply.hasErrors())
+            .isTrue();
+        assertThat(rpcReply.hasWarnings())
+            .isFalse();
+        assertThat(rpcReply.getErrors())
+            .containsExactly(RpcError.builder()
+                .errorType(RpcError.ErrorType.PROTOCOL)
+                .errorTag(RpcError.ErrorTag.OPERATION_FAILED)
+                .errorSeverity(RpcError.ErrorSeverity.ERROR)
+                .errorMessage("syntax error")
+                .errorInfo(RpcError.RpcErrorInfo.builder()
+                    .badElement("foobar")
+                    .build())
+                .build());
+    }
+
+    @Test
+    public void willParseAnErrorResponseWithNamespacePrefix() throws Exception {
+
+        final RpcReplyLoadConfigResults rpcReply = RpcReply.from(LOAD_CONFIG_RESULTS_ERROR_WITH_NAMESPACE);
+
+        assertThat(rpcReply.getMessageId())
+            .isEqualTo("6");
+        assertThat(rpcReply.getAction())
+            .isEqualTo("set");
+        assertThat(rpcReply.isOk())
+            .isTrue();
+        assertThat(rpcReply.hasErrorsOrWarnings())
+            .isTrue();
+        assertThat(rpcReply.hasErrors())
+            .isTrue();
+        assertThat(rpcReply.hasWarnings())
+            .isFalse();
+        assertThat(rpcReply.getErrors())
+            .containsExactly(RpcError.builder()
+                .errorType(RpcError.ErrorType.PROTOCOL)
+                .errorTag(RpcError.ErrorTag.OPERATION_FAILED)
+                .errorSeverity(RpcError.ErrorSeverity.ERROR)
+                .errorMessage("syntax error")
+                .errorInfo(RpcError.RpcErrorInfo.builder()
+                    .badElement("foobar")
+                    .build())
+                .build());
+    }
+
+    @Test
+    public void willCreateXmlOkWithoutNamespace() {
+
+        final RpcReply rpcReply = RpcReplyLoadConfigResults.loadConfigResultsBuilder()
+            .messageId("3")
+            .action("set")
+            .ok(true)
+            .build();
+
+        XmlAssert.assertThat(rpcReply.getXml())
+            .and(LOAD_CONFIG_RESULTS_OK_NO_NAMESPACE)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+
+    @Test
+    public void willCreateXmlOkWithNamespace() {
+
+        final RpcReply rpcReply = RpcReplyLoadConfigResults.loadConfigResultsBuilder()
+            .namespacePrefix("nc")
+            .messageId("4")
+            .action("set")
+            .ok(true)
+            .build();
+
+        XmlAssert.assertThat(rpcReply.getXml())
+            .and(LOAD_CONFIG_RESULTS_OK_WITH_NAMESPACE)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+
+    @Test
+    public void willCreateXmlErrorWithoutNamespace() {
+
+        final RpcReply rpcReply = RpcReplyLoadConfigResults.loadConfigResultsBuilder()
+            .messageId("5")
+            .action("set")
+            .ok(true)
+            .error(RpcError.builder()
+                .errorType(RpcError.ErrorType.PROTOCOL)
+                .errorTag(RpcError.ErrorTag.OPERATION_FAILED)
+                .errorSeverity(RpcError.ErrorSeverity.ERROR)
+                .errorMessage("syntax error")
+                .errorInfo(RpcError.RpcErrorInfo.builder()
+                    .badElement("foobar")
+                    .build())
+                .build())
+            .build();
+
+        XmlAssert.assertThat(rpcReply.getXml())
+            .and(LOAD_CONFIG_RESULTS_ERROR_NO_NAMESPACE)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+
+    @Test
+    public void willCreateXmlErrorWithNamespace() {
+
+        final RpcReply rpcReply = RpcReplyLoadConfigResults.loadConfigResultsBuilder()
+            .namespacePrefix("nc")
+            .messageId("6")
+            .action("set")
+            .ok(true)
+            .error(RpcError.builder()
+                .errorType(RpcError.ErrorType.PROTOCOL)
+                .errorTag(RpcError.ErrorTag.OPERATION_FAILED)
+                .errorSeverity(RpcError.ErrorSeverity.ERROR)
+                .errorMessage("syntax error")
+                .errorInfo(RpcError.RpcErrorInfo.builder()
+                    .badElement("foobar")
+                    .build())
+                .build())
+            .build();
+
+        XmlAssert.assertThat(rpcReply.getXml())
+            .and(LOAD_CONFIG_RESULTS_ERROR_WITH_NAMESPACE)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+
+}

--- a/src/test/java/net/juniper/netconf/element/RpcReplyTest.java
+++ b/src/test/java/net/juniper/netconf/element/RpcReplyTest.java
@@ -1,0 +1,193 @@
+package net.juniper.netconf.element;
+
+import org.junit.Test;
+import org.xmlunit.assertj.XmlAssert;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RpcReplyTest {
+
+    private static final String RPC_REPLY_WITHOUT_NAMESPACE = "" +
+        "<rpc-reply xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\"\n" +
+        "   message-id=\"3\"\n" +
+        "/>";
+    private static final String RPC_REPLY_WITH_NAMESPACE = "" +
+        "<nc:rpc-reply xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\"\n" +
+        "   message-id=\"4\"\n" +
+        "/>";
+    private static final String RPC_REPLY_WITH_OK = "" +
+        "<nc:rpc-reply xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\"\n" +
+        "    message-id=\"5\">\n" +
+        "    <nc:ok/>\n" +
+        "</nc:rpc-reply>";
+    // Example from https://datatracker.ietf.org/doc/html/rfc6241#section-4.3
+    private static final String RPC_REPLY_WITH_ERRORS = "" +
+        "<rpc-reply message-id=\"101\"\n" +
+        "           xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">\n" +
+        "    <rpc-error>\n" +
+        "        <error-type>application</error-type>\n" +
+        "        <error-tag>invalid-value</error-tag>\n" +
+        "        <error-severity>error</error-severity>\n" +
+        "        <error-path xmlns:t=\"http://example.com/schema/1.2/config\">/t:top/t:interface[t:name=\"Ethernet0/0\"]/t:mtu</error-path>\n" +
+        "        <error-message xml:lang=\"en\">MTU value 25000 is not within range 256..9192</error-message>\n" +
+        "    </rpc-error>\n" +
+        "    <rpc-error>\n" +
+        "        <error-type>application</error-type>\n" +
+        "        <error-tag>invalid-value</error-tag>\n" +
+        "        <error-severity>error</error-severity>\n" +
+        "        <error-path xmlns:t=\"http://example.com/schema/1.2/config\">/t:top/t:interface[t:name=\"Ethernet1/0\"]/t:address/t:name</error-path>\n" +
+        "        <error-message>Invalid IP address for interface Ethernet1/0</error-message>\n" +
+        "    </rpc-error>\n" +
+        "</rpc-reply>";
+
+    @Test
+    public void willParseRpcReplyWithoutNamespace() throws Exception {
+        final RpcReply rpcReply = RpcReply.from(RPC_REPLY_WITHOUT_NAMESPACE);
+
+        assertThat(rpcReply.getMessageId())
+            .isEqualTo("3");
+        assertThat(rpcReply.isOk())
+            .isFalse();
+        assertThat(rpcReply.hasErrorsOrWarnings())
+            .isFalse();
+        assertThat(rpcReply.hasErrors())
+            .isFalse();
+        assertThat(rpcReply.hasWarnings())
+            .isFalse();
+    }
+
+    @Test
+    public void willParseRpcReplyWithNamespace() throws Exception {
+        final RpcReply rpcReply = RpcReply.from(RPC_REPLY_WITH_NAMESPACE);
+
+        assertThat(rpcReply.getMessageId())
+            .isEqualTo("4");
+        assertThat(rpcReply.isOk())
+            .isFalse();
+        assertThat(rpcReply.hasErrorsOrWarnings())
+            .isFalse();
+        assertThat(rpcReply.hasErrors())
+            .isFalse();
+        assertThat(rpcReply.hasWarnings())
+            .isFalse();
+    }
+
+    @Test
+    public void willCreateOkRpcReply() throws Exception {
+        final RpcReply rpcReply = RpcReply.from(RPC_REPLY_WITH_OK);
+
+        assertThat(rpcReply.getMessageId())
+            .isEqualTo("5");
+        assertThat(rpcReply.isOk())
+            .isTrue();
+        assertThat(rpcReply.hasErrorsOrWarnings())
+            .isFalse();
+        assertThat(rpcReply.hasErrors())
+            .isFalse();
+        assertThat(rpcReply.hasWarnings())
+            .isFalse();
+    }
+
+    @Test
+    public void willParseRpcReplyWithErrors() throws Exception {
+        final RpcReply rpcReply = RpcReply.from(RPC_REPLY_WITH_ERRORS);
+
+        assertThat(rpcReply.getMessageId())
+            .isEqualTo("101");
+        assertThat(rpcReply.isOk())
+            .isFalse();
+        assertThat(rpcReply.hasErrorsOrWarnings())
+            .isTrue();
+        assertThat(rpcReply.hasErrors())
+            .isTrue();
+        assertThat(rpcReply.hasWarnings())
+            .isFalse();
+        assertThat(rpcReply.getErrors())
+            .isEqualTo(Arrays.asList(
+                RpcError.builder()
+                    .errorType(RpcError.ErrorType.APPLICATION)
+                    .errorTag(RpcError.ErrorTag.INVALID_VALUE)
+                    .errorSeverity(RpcError.ErrorSeverity.ERROR)
+                    .errorPath("/t:top/t:interface[t:name=\"Ethernet0/0\"]/t:mtu")
+                    .errorMessage("MTU value 25000 is not within range 256..9192")
+                    .errorMessageLanguage("en")
+                    .build(),
+                RpcError.builder()
+                    .errorType(RpcError.ErrorType.APPLICATION)
+                    .errorTag(RpcError.ErrorTag.INVALID_VALUE)
+                    .errorSeverity(RpcError.ErrorSeverity.ERROR)
+                    .errorPath("/t:top/t:interface[t:name=\"Ethernet1/0\"]/t:address/t:name")
+                    .errorMessage("Invalid IP address for interface Ethernet1/0")
+                    .build()));
+    }
+
+    @Test
+    public void willCreateXmlFromAnObject() {
+
+        final RpcReply rpcReply = RpcReply.builder()
+            .messageId("3")
+            .build();
+
+        XmlAssert.assertThat(rpcReply.getXml())
+            .and(RPC_REPLY_WITHOUT_NAMESPACE)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+
+    @Test
+    public void willCreateXmlWithNamespaceFromAnObject() {
+        final RpcReply rpcReply = RpcReply.builder()
+            .namespacePrefix("nc")
+            .messageId("4")
+            .build();
+
+        XmlAssert.assertThat(rpcReply.getXml())
+            .and(RPC_REPLY_WITH_NAMESPACE)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+
+    @Test
+    public void willCreateXmlWithOkFromAnObject() {
+
+        final RpcReply rpcReply = RpcReply.builder()
+            .namespacePrefix("nc")
+            .messageId("5")
+            .ok(true)
+            .build();
+
+        XmlAssert.assertThat(rpcReply.getXml())
+            .and(RPC_REPLY_WITH_OK)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+
+    @Test
+    public void willCreateXmlWithErrors() {
+        final RpcReply rpcReply = RpcReply.builder()
+            .messageId("101")
+            .error(RpcError.builder()
+                .errorType(RpcError.ErrorType.APPLICATION)
+                .errorTag(RpcError.ErrorTag.INVALID_VALUE)
+                .errorSeverity(RpcError.ErrorSeverity.ERROR)
+                .errorPath("/t:top/t:interface[t:name=\"Ethernet0/0\"]/t:mtu")
+                .errorMessage("MTU value 25000 is not within range 256..9192")
+                .errorMessageLanguage("en")
+                .build())
+            .error(RpcError.builder()
+                .errorType(RpcError.ErrorType.APPLICATION)
+                .errorTag(RpcError.ErrorTag.INVALID_VALUE)
+                .errorSeverity(RpcError.ErrorSeverity.ERROR)
+                .errorPath("/t:top/t:interface[t:name=\"Ethernet1/0\"]/t:address/t:name")
+                .errorMessage("Invalid IP address for interface Ethernet1/0")
+                .build())
+            .build();
+
+        XmlAssert.assertThat(rpcReply.getXml())
+            .and(RPC_REPLY_WITH_ERRORS)
+            .ignoreWhitespace()
+            .areIdentical();
+    }
+}


### PR DESCRIPTION
This builds on the earlier work for namespace-aware parsing of `<hello>`, and is now ready for review.

It introduces a new `RpcReply` class that is used to parse `<rpc-reply>` messages (with some refactoring of the `Hello` class to tease out common code).

Instead of searching for the text `<ok/>` in the String response, `NetconfSession` now uses the methods in `RpcReply` to determine if a response is OK (similarly for warning and errors).

Existing tests passes (a few textual exception messages changed slightly, I don't think that is a problem), and this also runs a suite of tests on my local device too.