### PR TITLE
Only depend on the SLF4 API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,8 +173,8 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.12</version>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>xalan</groupId>


### PR DESCRIPTION
The user of the library includes a logging dependency. Most spring and
micronaut projects use logback, and that works perfectly with the slf4j
APIs. It conflicts with the slf4j-log4j12 dependency, however, and
that's surprising as a library consumer, it requires special logic to
exclude the dependency.