### PR TITLE
Hotfix: removal of `-eks` from version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.juniper.netconf</groupId>
     <artifactId>netconf-java</artifactId>
-    <version>2.1.1.6.2-eks</version>
+    <version>2.1.1.6.3</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
`eks` comes from my custom build. It should be removed here.