### PR TITLE
updated xmlunit assertJ to fix dependabot issue for CVE-2024-31573

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'net.juniper.netconf'
-version = '2.2.0.0'
+version = '2.2.0.1'
 description = 'An API For NetConf client'
 
 java {
@@ -29,7 +29,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.mockito:mockito-core:4.8.1'
     testImplementation 'commons-io:commons-io:2.14.0'
-    testImplementation 'org.xmlunit:xmlunit-assertj:2.9.0'
+    testImplementation 'org.xmlunit:xmlunit-assertj:2.10.0'
     testImplementation 'org.slf4j:slf4j-simple:2.0.3'
     testImplementation 'com.github.spotbugs:spotbugs-annotations:4.7.3'
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.juniper.netconf</groupId>
     <artifactId>netconf-java</artifactId>
-    <version>2.2.0.0</version>
+    <version>2.2.0.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -217,7 +217,7 @@
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-assertj</artifactId>
-            <version>2.9.0</version>
+            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Fixes issue found in CVE-2024-31573.
Updated xmlunit assertJ to recommended version.